### PR TITLE
Make it responsive

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,5 +1,6 @@
 <head>
 	<title>Meteoro</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 
 <body>
@@ -11,7 +12,7 @@
 		{{> pomodoro }}
 		<hr />
 		{{> oldPomodoros }}
-		<a href="https://github.com/AZdv/meteoro" target="_blank" class="github-fork">
+		<a href="https://github.com/AZdv/meteoro" target="_blank" class="github-fork hidden-xs">
 			<img src="https://camo.githubusercontent.com/567c3a48d796e2fc06ea80409cc9dd82bf714434/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png">
 		</a>
 	</div>
@@ -27,7 +28,10 @@
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
 				</button>
-				<a class="navbar-brand" href="#"><span id="logo">{{projectName}}</span> - {{projectSlogan}}</a>
+				<a class="navbar-brand" href="#">
+                    <span id="logo">{{projectName}}</span>
+                    <span class="hidden-xs"> - {{projectSlogan}}</span>
+                </a>
 			</div>
 			<div class="collapse navbar-collapse">
 				<p class="navbar-text navbar-right">{{> login}}</p>
@@ -38,20 +42,34 @@
 
 <template name="pomodoro">
 	<div class="pomodoro-container">
-		<div class="pomodoro-time">
-			<div class="pomodoro-tomato-pic"></div>
-			<div class="pomodoro-tomato-empty-pic" style="height: {{pomodoroHeight 500}}px"></div>
-			<div class="pomodoro-current-time">{{currentPomodoroTime}}</div>
+        <div class="hack">
+            <div class="pomodoro-time">
+                <div class="pomodoro-tomato-pic"></div>
+                <div class="pomodoro-tomato-empty-pic" style="height: {{pomodoroHeight 500}}px"></div>
+                <div class="pomodoro-current-time">{{currentPomodoroTime}}</div>
+            </div>
+        </div>
+		<div class="pomodoro-buttons row">
+            <div class="col-sm-4 form-group">
+                <button type="button" class="btn btn-block btn-lg btn-success pomodoro-start {{#if pomodoroTimer}} disabled {{/if}}">Start</button>
+            </div>
+            <div class="col-sm-4 form-group">
+                <button type="button" class="btn btn-block btn-lg btn-danger pomodoro-stop {{#unless pomodoroTimer}} disabled {{/unless}}">Stop</button>
+            </div>
+            <div class="col-sm-4 form-group">
+                <button type="button" class="btn btn-block btn-lg btn-default pomodoro-reset">Reset</button>
+            </div>
 		</div>
-		<div class="pomodoro-buttons">
-			<button type="button" class="btn btn-lg btn-success pomodoro-start {{#if pomodoroTimer}} disabled {{/if}}">Start</button>
-			<button type="button" class="btn btn-lg btn-danger pomodoro-stop {{#unless pomodoroTimer}} disabled {{/unless}}">Stop</button>
-			<button type="button" class="btn btn-lg btn-default pomodoro-reset">Reset</button>
-		</div>
-		<div class="pomodoro-buttons pomodoro-buttons-types">
-			<button type="button" class="btn btn-lg btn-danger pomodoro-change-type {{#if timerTypeCompare 'POMODORO_TIME' }} disabled {{/if}}" data-type="POMODORO_TIME">Pomodoro</button>
-			<button type="button" class="btn btn-lg btn-default pomodoro-change-type {{#if timerTypeCompare 'SHORT_BREAK_TIME' }} disabled {{/if}}" data-type="SHORT_BREAK_TIME">Short Break</button>
-			<button type="button" class="btn btn-lg btn-default pomodoro-change-type {{#if timerTypeCompare 'LONG_BREAK_TIME' }} disabled {{/if}}" data-type="LONG_BREAK_TIME">Long Break</button>
+		<div class="pomodoro-buttons pomodoro-buttons-types row">
+            <div class="col-sm-4 form-group">
+                <button type="button" class="btn btn-block btn btn-danger pomodoro-change-type {{#if timerTypeCompare 'POMODORO_TIME' }} disabled {{/if}}" data-type="POMODORO_TIME">Pomodoro</button>
+            </div>
+            <div class="col-sm-4 form-group">
+                <button type="button" class="btn btn-block btn btn-default pomodoro-change-type {{#if timerTypeCompare 'SHORT_BREAK_TIME' }} disabled {{/if}}" data-type="SHORT_BREAK_TIME">Short Break</button>
+            </div>
+            <div class="col-sm-4 form-group">
+                <button type="button" class="btn btn-block btn btn-default pomodoro-change-type {{#if timerTypeCompare 'LONG_BREAK_TIME' }} disabled {{/if}}" data-type="LONG_BREAK_TIME">Long Break</button>
+            </div>
 		</div>
 	</div>	
 </template>

--- a/client/style.css
+++ b/client/style.css
@@ -39,14 +39,17 @@
 	text-align: center;
 }
 .pomodoro-time {
-	width: 500px;
+	width: auto;
+    max-width: 500px;
 	height: 500px;
 	margin: 20px auto;
 }
 .pomodoro-tomato-empty-pic, .pomodoro-tomato-pic {
 	position: absolute;
-	width: 500px;
+    width: 92%; /* since absolute elements don't respect padding, this value has been picked by experiment */
+	max-width: 500px;
 	height: 500px;
+    background-position: center top;
 }
 .pomodoro-current-time {
 	position: relative;
@@ -59,6 +62,7 @@
 .pomodoro-tomato-empty-pic {
 	background-image: url( 'images/tomato_empty.png' );
 }
+/*
 .pomodoro-buttons button {
 	margin-right: 20px;
 }
@@ -68,6 +72,7 @@
 .pomodoro-buttons-types {
 	margin-top: 30px;
 }
+*/
 .btn:focus,
 .btn:active:focus,
 .btn.active:focus,

--- a/client/style.css
+++ b/client/style.css
@@ -40,16 +40,16 @@
 }
 .pomodoro-time {
 	width: auto;
-    max-width: 500px;
+	max-width: 500px;
 	height: 500px;
 	margin: 20px auto;
 }
 .pomodoro-tomato-empty-pic, .pomodoro-tomato-pic {
 	position: absolute;
-    width: 92%; /* since absolute elements don't respect padding, this value has been picked by experiment */
+	width: 92%; /* since absolute elements don't respect padding, this value has been picked by experiment */
 	max-width: 500px;
 	height: 500px;
-    background-position: center top;
+	background-position: center top;
 }
 .pomodoro-current-time {
 	position: relative;


### PR DESCRIPTION
A little adjustment to CSS and index.html to make UI look a little better on mobile devices, all within Twitter Bootstrap CSS conventions.

Changes:
- added viewport declaration with `initial-scale=1` to index.html to auto-scale the page on mobile devices.
- tweaked `width` and `max-width` of image containers to center and cut it on small screens; the next step is to scale it to fit the whole tomato into screen width.

Checked on iPhone 5s and iPad Mini 1st gen. Looks nice, but there's a lot of space for improvement.
